### PR TITLE
Fixed small_flowers block tag

### DIFF
--- a/common/src/main/resources/data/minecraft/tags/blocks/small_flowers.json
+++ b/common/src/main/resources/data/minecraft/tags/blocks/small_flowers.json
@@ -1,4 +1,5 @@
 {
+    "replace": false,
     "values": [
         "sprout:black_allium",
         "sprout:black_azure_bluet",


### PR DESCRIPTION
Because in my private modpack (fabric), 
this block tag overwrites other small_flowers block tags from other mods somehow