### PR TITLE
Change black/brown flower odds from 0.05% to 0.5%

### DIFF
--- a/common/src/main/java/tech/thatgravyboat/sprout/common/flowers/FlowerBreedTree.java
+++ b/common/src/main/java/tech/thatgravyboat/sprout/common/flowers/FlowerBreedTree.java
@@ -40,8 +40,8 @@ public class FlowerBreedTree {
             Builder builder = new Builder(Blocks.WITHER_ROSE, block2);
             builder.add(Blocks.WITHER_ROSE, 49.95);
             builder.add(block2, 49.95);
-            builder.add(SproutFlowers.FLOWERS.get(FlowerColor.BLACK).get(flower2.getFirst()), 0.05);
-            builder.add(SproutFlowers.FLOWERS.get(FlowerColor.BROWN).get(flower2.getFirst()), 0.05);
+            builder.add(SproutFlowers.FLOWERS.get(FlowerColor.BLACK).get(flower2.getFirst()), 0.5);
+            builder.add(SproutFlowers.FLOWERS.get(FlowerColor.BROWN).get(flower2.getFirst()), 0.5);
             register(builder);
         }
 

--- a/common/src/main/java/tech/thatgravyboat/sprout/common/flowers/FlowerBreedTree.java
+++ b/common/src/main/java/tech/thatgravyboat/sprout/common/flowers/FlowerBreedTree.java
@@ -38,8 +38,8 @@ public class FlowerBreedTree {
         for (var flower2 : combinedFlowers) {
             Block block2 = SproutFlowers.FLOWERS.get(flower2.getSecond()).get(flower2.getFirst()).get();
             Builder builder = new Builder(Blocks.WITHER_ROSE, block2);
-            builder.add(Blocks.WITHER_ROSE, 49.95);
-            builder.add(block2, 49.95);
+            builder.add(Blocks.WITHER_ROSE, 49.5);
+            builder.add(block2, 49.5);
             builder.add(SproutFlowers.FLOWERS.get(FlowerColor.BLACK).get(flower2.getFirst()), 0.5);
             builder.add(SproutFlowers.FLOWERS.get(FlowerColor.BROWN).get(flower2.getFirst()), 0.5);
             register(builder);


### PR DESCRIPTION
From my understanding from issue https://github.com/ThatGravyBoat/Sprout/issues/36 the intention was for the combined odds to get black or brown to be 1%.

However, the code actually had it at 0.05% each, and thus the combined odds were 0.1%. 10 times less likely.